### PR TITLE
Check page content when tab activated

### DIFF
--- a/src/ts/browser/sender.ts
+++ b/src/ts/browser/sender.ts
@@ -1,6 +1,13 @@
 import { MessageGeneric } from "../messages/types";
 import { browser } from "webextension-polyfill-ts";
 
+export const sendMessageToTab = async (
+  tabId: number,
+  message: MessageGeneric<any>
+) => {
+  await browser.tabs.sendMessage(tabId, message);
+};
+
 export const sendMessageToActiveCurrentWindowTab = async (
   message: MessageGeneric<any>
 ) => {
@@ -9,7 +16,7 @@ export const sendMessageToActiveCurrentWindowTab = async (
     active: true,
     currentWindow: true,
   });
-  await browser.tabs.sendMessage(tabs[0].id, message);
+  await sendMessageToTab(tabs[0].id, message);
 };
 
 export const sendRuntimeMessage = async (msg: MessageGeneric<any>) => {

--- a/src/ts/content/handlers.ts
+++ b/src/ts/content/handlers.ts
@@ -38,13 +38,28 @@ function colorSelection() {
   }
 }
 
+const handleCheckIfApi = async () => {
+  const body = document.body;
+  const textContent = body.innerText || body.textContent;
+  const regexToTest = /API/;
+  const isApi = regexToTest.test(textContent);
+  console.log(`API check result: ${isApi}`);
+  sender.sendRuntimeMessage({
+    type: messages.MessageType.SET_BADGE,
+    props: {
+      isApi,
+    },
+  });
+};
+
 const messageHandler = async (request, _) => {
   console.log(`Got message: ${JSON.stringify(request)}`);
   if (messages.SelectionHandled.matches(request)) {
     colorSelection();
-  }
-  if (messages.SelectionRequest.matches(request)) {
+  } else if (messages.SelectionRequest.matches(request)) {
     await handleSelectionRequest();
+  } else if (request.type === messages.MessageType.CHECK_IF_API) {
+    await handleCheckIfApi();
   }
 };
 

--- a/src/ts/content/handlers.ts
+++ b/src/ts/content/handlers.ts
@@ -52,6 +52,7 @@ const handleCheckIfApi = async () => {
   });
 };
 
+// TODO: Remove the mish mash of very strict and lazy type-checking using both `...matches(request)` and `request.type === ...`
 const messageHandler = async (request, _) => {
   console.log(`Got message: ${JSON.stringify(request)}`);
   if (messages.SelectionHandled.matches(request)) {

--- a/src/ts/content/handlers.ts
+++ b/src/ts/content/handlers.ts
@@ -41,7 +41,7 @@ function colorSelection() {
 const handleCheckIfApi = async () => {
   const body = document.body;
   const textContent = body.innerText || body.textContent;
-  const regexToTest = /API/;
+  const regexToTest = /\bAPI\b/;
   const isApi = regexToTest.test(textContent);
   console.log(`API check result: ${isApi}`);
   sender.sendRuntimeMessage({

--- a/src/ts/messages/types.ts
+++ b/src/ts/messages/types.ts
@@ -5,6 +5,8 @@ export enum MessageType {
   SELECT_ENDPOINT = "Select endpoint",
   SET_ACTIVE_URL = "Set active URL",
   CLEAR = "Clear",
+  CHECK_IF_API = "Check if is API page",
+  SET_BADGE = "Set badge for browser action button",
 }
 
 interface MessageProps {}


### PR DESCRIPTION
Whenever tab is activated, ask content script to read the page (text) content and to check if anything in it matches to "API" (which is of course super-crude). Then send message to background script to set the badge text to either "API" or empty, depending on the content script result.

Imagined workflow (Phase 1 before any of the trickier stuff):
1) User navigates to API documentation page
2) Browser action button shows the "API" badge
3) User opens the Swagger editor from the pop-up
4) Editor is opened with auto-filled description, paths, operations, etc. (what-ever can be done relatively easily)
5) If the user wants to add stuff from another page, he can navigate to that page and click some "add page" button from the Swagger editor to auto-fill paths from the new page (probably phase 2)
6) User fills in the stuff he needs and exports the spec

This is mostly a demonstration of interacting with the page dom and is not intended to be efficient in any way (one could, for example, memorize the "API check"  result per tab ID or URL to avoid doing it everytime a tab is changed). 