### PR TITLE
Auto-fill Swagger content from the page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook -c .storybook -o .storybook-static",
     "test-storybook": "start-storybook -p 6006 --smoke-test",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "type-check": "tsc"
   },
   "dependencies": {
     "bootstrap": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "bootstrap": "^4.3.1",
+    "debug": "^4.1.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.11",
     "react": "^16.8.6",
@@ -34,6 +35,7 @@
     "@storybook/addons": "^5.0.10",
     "@storybook/react": "^5.0.10",
     "@types/chrome": "^0.0.82",
+    "@types/debug": "^4.1.4",
     "@types/enzyme": "^3.9.1",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "^24.0.11",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "bootstrap": "^4.3.1",
+    "js-yaml": "^3.13.1",
     "lodash": "^4.17.11",
     "react": "^16.8.6",
     "react-bootstrap": "^1.0.0-beta.8",
@@ -36,6 +37,7 @@
     "@types/enzyme": "^3.9.1",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "^24.0.11",
+    "@types/js-yaml": "^3.12.1",
     "@types/lodash": "^4.14.123",
     "@types/node": "^11.13.4",
     "@types/react": "^16.8.13",

--- a/src/popup.html
+++ b/src/popup.html
@@ -6,13 +6,6 @@
 <html>
   <body>
     <div>
-      <button id="set-active">Set active URL</button>
-      <div id="output"></div>
-    </div>
-    <div>
-      <button id="open">Open explorer</button>
-    </div>
-    <div>
       <button id="open-swagger-editor">Open Swagger editor</button>
     </div>
   </body>

--- a/src/ts/browser/sender.ts
+++ b/src/ts/browser/sender.ts
@@ -20,7 +20,14 @@ export const sendMessageToActiveCurrentWindowTab = async (
     active: true,
     currentWindow: true,
   });
-  await sendMessageToTab(tabs[0].id, message);
+  if (tabs.length === 0) {
+    console.warn("No active tabs, cannot send message");
+    return;
+  }
+  const tabId = tabs[0].id;
+  if (tabId) {
+    await sendMessageToTab(tabId, message);
+  }
 };
 
 export const sendRuntimeMessage = async (msg: MessageGeneric<any>) => {

--- a/src/ts/browser/sender.ts
+++ b/src/ts/browser/sender.ts
@@ -5,7 +5,7 @@ export const sendMessageToTab = async (
   tabId: number,
   message: MessageGeneric<any>
 ) => {
-  await browser.tabs.sendMessage(tabId, message);
+  return browser.tabs.sendMessage(tabId, message);
 };
 
 export const sendMessageToActiveCurrentWindowTab = async (

--- a/src/ts/browser/sender.ts
+++ b/src/ts/browser/sender.ts
@@ -1,17 +1,21 @@
 import { MessageGeneric } from "../messages/types";
 import { browser } from "webextension-polyfill-ts";
+import debug from "../common/logging";
+
+const debugLog = debug("unmock:sender");
 
 export const sendMessageToTab = async (
   tabId: number,
   message: MessageGeneric<any>
 ) => {
+  debugLog(`Sending message to tab ${tabId}`);
   return browser.tabs.sendMessage(tabId, message);
 };
 
 export const sendMessageToActiveCurrentWindowTab = async (
   message: MessageGeneric<any>
 ) => {
-  console.log(`Sending message: ${JSON.stringify(message)}`);
+  debugLog(`Sending message: ${JSON.stringify(message)}`);
   const tabs = await browser.tabs.query({
     active: true,
     currentWindow: true,

--- a/src/ts/browser/storage.ts
+++ b/src/ts/browser/storage.ts
@@ -39,10 +39,10 @@ export const setTabInfo = async (tabInfo: TabInfo) => {
   await browser.storage.local.set({ [STORAGE_TABINFO_KEY]: tabInfo });
 };
 
-export const getTabInfo = async (): Promise<TabInfo | null> => {
+export const getTabInfo = async (): Promise<TabInfo | undefined> => {
   const tabInfoResult = await browser.storage.local.get(STORAGE_TABINFO_KEY);
   console.log("TabInfo result", JSON.stringify(tabInfoResult));
-  return tabInfoResult[STORAGE_TABINFO_KEY] || null;
+  return tabInfoResult[STORAGE_TABINFO_KEY];
 };
 
 export const getLocalStorage = async (): Promise<State> => {

--- a/src/ts/browser/storage.ts
+++ b/src/ts/browser/storage.ts
@@ -6,7 +6,6 @@ import UserStateMachine, {
   UserStateConfig,
 } from "../common/machine";
 import * as _ from "lodash";
-
 /**
  * These must match with the keys of `State` interface
  */

--- a/src/ts/browser/storage.ts
+++ b/src/ts/browser/storage.ts
@@ -1,4 +1,4 @@
-import { Labeled, State, defaultLabeled } from "../state";
+import { Labeled, State, defaultLabeled, TabInfo } from "../state";
 import { browser } from "webextension-polyfill-ts";
 import UserStateMachine, {
   createState,
@@ -12,6 +12,7 @@ import * as _ from "lodash";
  */
 const STORAGE_LABELED_KEY = "labeled";
 const STORAGE_USERSTATE_KEY = "userState";
+const STORAGE_TABINFO_KEY = "tabInfo";
 
 export const getLabeled = async (): Promise<Labeled> => {
   const labeledResult = await browser.storage.local.get([STORAGE_LABELED_KEY]);
@@ -33,6 +34,16 @@ export const getUserState = async (): Promise<UserState> => {
   const persistedUserState = await getUserStateConfig();
 
   return UserStateMachine.resolveState(createState(persistedUserState));
+};
+
+export const setTabInfo = async (tabInfo: TabInfo) => {
+  await browser.storage.local.set({ [STORAGE_TABINFO_KEY]: tabInfo });
+};
+
+export const getTabInfo = async (): Promise<TabInfo | null> => {
+  const tabInfoResult = await browser.storage.local.get(STORAGE_TABINFO_KEY);
+  console.log("TabInfo result", JSON.stringify(tabInfoResult));
+  return tabInfoResult[STORAGE_TABINFO_KEY] || null;
 };
 
 export const getLocalStorage = async (): Promise<State> => {

--- a/src/ts/browser/store.ts
+++ b/src/ts/browser/store.ts
@@ -1,7 +1,7 @@
 import * as _ from "lodash";
 import { Labeled } from "../state";
 import { UserState, persistedUserStateMachine } from "../common/machine";
-import { getLabeled, setLabeled } from "./storage";
+import { getLabeled, setLabeled, setTabInfo, getTabInfo } from "./storage";
 
 export const setActiveUrl = async (url: string) => {
   // Transition state
@@ -19,6 +19,10 @@ export const setActiveUrl = async (url: string) => {
   const newLabeled = { ...withoutUrl, [url]: newLabeledForUrl };
   console.log("Setting new labeled", newLabeled);
   await setLabeled(newLabeled);
+};
+
+export const setTabIdOpeningSwagger = async (tabId: number) => {
+  await setTabInfo({ tabId });
 };
 
 export const checkIsActiveUrl = async (url: string): Promise<boolean> => {

--- a/src/ts/browser/store.ts
+++ b/src/ts/browser/store.ts
@@ -80,7 +80,7 @@ export const addNewPath = async (
   const activeUrl = userState.context.url;
   if (!activeUrl) {
     console.warn("No active url, returning");
-    return;
+    return [];
   }
   // Needs to be array to avoid the mess with periods in URL
   const insertionPath: string[] = [activeUrl];

--- a/src/ts/browser/utils.ts
+++ b/src/ts/browser/utils.ts
@@ -1,5 +1,5 @@
 import { browser, Tabs } from "webextension-polyfill-ts";
-import { getLocalStorage } from "./storage";
+import { getLocalStorage, setTabInfo } from "./storage";
 import { State } from "../state";
 
 export const getActiveTab = async (): Promise<Tabs.Tab> => {
@@ -30,9 +30,7 @@ export const openSwaggerEditor = async () => {
   const activeTab = await getActiveTab();
   const activeTabId = activeTab.id;
   console.log(`Setting active tab ID: ${activeTabId}`);
-  await browser.storage.local.set({
-    tabIdOpenWhenSwaggerOpened: activeTabId,
-  });
+  await setTabInfo({ tabId: activeTabId });
   return await browser.windows.create({
     url: browser.runtime.getURL("swagger.html"),
     type: "popup",

--- a/src/ts/browser/utils.ts
+++ b/src/ts/browser/utils.ts
@@ -26,6 +26,13 @@ export const openExplorer = async () => {
 
 export const openSwaggerEditor = async () => {
   const width = window.screen.availWidth;
+  // Remember which tab opened the Swagger editor
+  const activeTab = await getActiveTab();
+  const activeTabId = activeTab.id;
+  console.log(`Setting active tab ID: ${activeTabId}`);
+  await browser.storage.local.set({
+    tabIdOpenWhenSwaggerOpened: activeTabId,
+  });
   return await browser.windows.create({
     url: browser.runtime.getURL("swagger.html"),
     type: "popup",

--- a/src/ts/common/logging.ts
+++ b/src/ts/common/logging.ts
@@ -1,0 +1,6 @@
+import debug from "debug";
+
+// TODO Control this from webpack build?
+debug.enable("unmock:*");
+
+export default debug;

--- a/src/ts/common/types.ts
+++ b/src/ts/common/types.ts
@@ -1,0 +1,5 @@
+export interface PageContent {
+  title: string;
+  innerHtml: string;
+  textContent: string;
+}

--- a/src/ts/content/handlers.ts
+++ b/src/ts/content/handlers.ts
@@ -52,6 +52,12 @@ const handleCheckIfApi = async () => {
   });
 };
 
+const handleGetContent = () => {
+  const body = document.body;
+  const textContent = body.innerText || body.textContent;
+  return { title: document.title, textContent };
+};
+
 // TODO: Remove the mish mash of very strict and lazy type-checking using both `...matches(request)` and `request.type === ...`
 const messageHandler = async (request, _) => {
   console.log(`Got message: ${JSON.stringify(request)}`);
@@ -61,6 +67,10 @@ const messageHandler = async (request, _) => {
     await handleSelectionRequest();
   } else if (request.type === messages.MessageType.CHECK_IF_API) {
     await handleCheckIfApi();
+  } else if (request.type === messages.MessageType.GET_CONTENT) {
+    const textContent = handleGetContent();
+    console.log(`Responding with`, textContent);
+    return { response: textContent };
   }
 };
 

--- a/src/ts/content/handlers.ts
+++ b/src/ts/content/handlers.ts
@@ -1,6 +1,7 @@
 import * as messages from "../messages";
 import { MessageGeneric } from "../messages/types";
 import { sender } from "../browser";
+import { PageContent } from "../common/types";
 
 const sendMessage = async (msg: MessageGeneric<any>) => {
   console.log(`Sending message: ${JSON.stringify(msg)}`);
@@ -52,10 +53,11 @@ const handleCheckIfApi = async () => {
   });
 };
 
-const handleGetContent = () => {
+const handleGetPageContent = (): PageContent => {
   const body = document.body;
   const textContent = body.innerText || body.textContent;
-  return { title: document.title, textContent };
+  const innerHtml = document.documentElement.innerHTML;
+  return { title: document.title, innerHtml, textContent };
 };
 
 // TODO: Remove the mish mash of very strict and lazy type-checking using both `...matches(request)` and `request.type === ...`
@@ -68,9 +70,7 @@ const messageHandler = async (request, _) => {
   } else if (request.type === messages.MessageType.CHECK_IF_API) {
     await handleCheckIfApi();
   } else if (request.type === messages.MessageType.GET_CONTENT) {
-    const textContent = handleGetContent();
-    console.log(`Responding with`, textContent);
-    return { response: textContent };
+    return handleGetPageContent();
   }
 };
 

--- a/src/ts/messages/types.ts
+++ b/src/ts/messages/types.ts
@@ -7,6 +7,7 @@ export enum MessageType {
   CLEAR = "Clear",
   CHECK_IF_API = "Check if is API page",
   SET_BADGE = "Set badge for browser action button",
+  GET_CONTENT = "Get page content",
 }
 
 interface MessageProps {}

--- a/src/ts/popup/index.ts
+++ b/src/ts/popup/index.ts
@@ -1,20 +1,5 @@
 import "../../scss/popup.scss";
-import * as messages from "../messages";
-import { sender, utils } from "../browser";
-
-const setActive = document.getElementById("set-active");
-
-setActive.onclick = async () => {
-  const tab = await utils.getActiveTab();
-  const initializeMsg = messages.SetActiveUrl.build({ url: tab.url });
-  await sender.sendRuntimeMessage(initializeMsg);
-};
-
-const openButton = document.getElementById("open");
-
-openButton.onclick = () => {
-  utils.openExplorer();
-};
+import { utils } from "../browser";
 
 const openSwaggerEditorButton = document.getElementById("open-swagger-editor");
 

--- a/src/ts/state/index.ts
+++ b/src/ts/state/index.ts
@@ -1,4 +1,4 @@
-import { State, Labeled, Paths, Path } from "./types";
+import { State, Labeled, Paths, Path, TabInfo } from "./types";
 
 const defaultLabeled = {};
 
@@ -6,4 +6,4 @@ const defaultState = {
   labeled: defaultLabeled,
 };
 
-export { defaultLabeled, defaultState, State, Labeled, Paths, Path };
+export { defaultLabeled, defaultState, State, Labeled, Paths, Path, TabInfo };

--- a/src/ts/state/types.ts
+++ b/src/ts/state/types.ts
@@ -7,9 +7,21 @@ export interface State {
   labeled: Labeled;
 
   /**
+   * Any information related to user tabs
+   */
+  tabInfo?: TabInfo;
+
+  /**
    * User state (xstate)
    */
   userState: UserStateConfig;
+}
+
+export interface TabInfo {
+  /**
+   * Tab ID user had active when opening Swagger editor
+   */
+  tabId?: number;
 }
 
 export interface Labeled {

--- a/src/ts/swagger/index.ts
+++ b/src/ts/swagger/index.ts
@@ -40,13 +40,12 @@ const onWindowLoad = async () => {
 };
 
 const fillFromTab = async (updateSpec: (content: string) => void) => {
-  const result = (await storage.getTabInfo()) || {};
-  const tabIdOrUndefined = result.tabId;
-  if (!tabIdOrUndefined) {
+  const tabInfoOrNull = await storage.getTabInfo();
+  const tabId: number | undefined = tabInfoOrNull && tabInfoOrNull.tabId;
+  if (tabId === undefined) {
     console.warn("Cannot fill Swagger editor as no tab ID available");
     return;
   }
-  const tabId = tabIdOrUndefined;
   console.log(`Filling from tab ID: ${tabId}`);
   // Request content to fill from the background
   const pageContent: PageContent = await sender.sendMessageToTab(tabId, {

--- a/src/ts/swagger/index.ts
+++ b/src/ts/swagger/index.ts
@@ -34,7 +34,9 @@ const onWindowLoad = async () => {
 
   browser.runtime.onMessage.addListener(messageHandler);
 
-  await fillFromTab(editor.specActions.updateSpec.bind(editor.specActions));
+  // Does not seem to need `bind`
+  const setSpec = editor.unmockActions.setSpec;
+  await fillFromTab(setSpec);
 };
 
 const fillFromTab = async (updateSpec: (content: string) => void) => {

--- a/src/ts/swagger/wrap-spec-action.ts
+++ b/src/ts/swagger/wrap-spec-action.ts
@@ -18,17 +18,10 @@ export const WrapActionPlugin = () => (system: SwaggerEditor) => {
             system.specActions.updateSpec("");
             return { type: "CLEAR" };
           },
-          set: (str: string) => {
-            console.log(str);
-            system.specActions.updateSpec(
-              `openapi: ${new Date().toString()}\n`
-            );
+          setSpec: (str: string) => {
+            system.specActions.updateSpec(str);
+            // Need to return Redux action from here, not used
             return { type: "SET_SPEC", payload: str };
-          },
-        },
-        reducers: {
-          SET_SPEC: (state, action) => {
-            return state;
           },
         },
       },

--- a/src/ts/swagger/wrap-spec-action.ts
+++ b/src/ts/swagger/wrap-spec-action.ts
@@ -18,6 +18,18 @@ export const WrapActionPlugin = () => (system: SwaggerEditor) => {
             system.specActions.updateSpec("");
             return { type: "CLEAR" };
           },
+          set: (str: string) => {
+            console.log(str);
+            system.specActions.updateSpec(
+              `openapi: ${new Date().toString()}\n`
+            );
+            return { type: "SET_SPEC", payload: str };
+          },
+        },
+        reducers: {
+          SET_SPEC: (state, action) => {
+            return state;
+          },
         },
       },
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "lib": ["dom", "es2015", "es2016"],
-    "outDir": "dist"
+    "outDir": "dist",
+    "strictNullChecks": false
   },
   "include": ["src/ts"]
 }

--- a/utils/webserver.js
+++ b/utils/webserver.js
@@ -1,35 +1,34 @@
 var WebpackDevServer = require("webpack-dev-server"),
-    webpack = require("webpack"),
-    config = require("../webpack.config"),
-    env = require("./env"),
-    path = require("path");
+  webpack = require("webpack"),
+  config = require("../webpack.config"),
+  env = require("./env"),
+  path = require("path");
 
-var options = (config.chromeExtensionBoilerplate || {});
-var excludeEntriesToHotReload = (options.notHotReload || []);
+var options = config.chromeExtensionBoilerplate || {};
+var excludeEntriesToHotReload = options.notHotReload || [];
 
 for (var entryName in config.entry) {
   if (excludeEntriesToHotReload.indexOf(entryName) === -1) {
-    config.entry[entryName] =
-      [
-        ("webpack-dev-server/client?http://localhost:" + env.PORT),
-        "webpack/hot/dev-server"
-      ].concat(config.entry[entryName]);
+    config.entry[entryName] = [
+      "webpack-dev-server/client?http://localhost:" + env.PORT,
+      "webpack/hot/dev-server",
+    ].concat(config.entry[entryName]);
   }
 }
 
-config.plugins =
-  [new webpack.HotModuleReplacementPlugin()].concat(config.plugins || []);
+config.plugins = [new webpack.HotModuleReplacementPlugin()].concat(
+  config.plugins || []
+);
 
 delete config.chromeExtensionBoilerplate;
 
 var compiler = webpack(config);
 
-var server =
-  new WebpackDevServer(compiler, {
-    hot: true,
-    contentBase: path.join(__dirname, "../build"),
-    headers: { "Access-Control-Allow-Origin": "*" },
-    disableHostCheck: true
-  });
+var server = new WebpackDevServer(compiler, {
+  hot: true,
+  contentBase: path.join(__dirname, "../build"),
+  headers: { "Access-Control-Allow-Origin": "*" },
+  disableHostCheck: true,
+});
 
 server.listen(env.PORT);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,6 +1673,11 @@
   dependencies:
     "@types/filesystem" "*"
 
+"@types/debug@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.4.tgz#56eec47706f0fd0b7c694eae2f3172e6b0b769da"
+  integrity sha512-D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ==
+
 "@types/enzyme-adapter-react-16@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.5.tgz#1bf30a166f49be69eeda4b81e3f24113c8b4e9d5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1717,6 +1717,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/js-yaml@^3.12.1":
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.1.tgz#5c6f4a1eabca84792fbd916f0cb40847f123c656"
+  integrity sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==
+
 "@types/lodash@^4.14.123":
   version "4.14.123"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"


### PR DESCRIPTION
- When user opens Swagger editor, store the active tab ID to local storage. I could not figure out another way to tell Swagger editor which page content it should read when starting up.
- When Swagger editor starts, request page content from the content script running in the tab ID stored to local storage and use it to fill in the spec, (only sets the title for now for demo)
- Start to use `debug` from `common/logging` to avoid putting `console.log` everywhere, did not try to start using this everywhere yet

TODO in future:
- ⬆️Webpack config needs clean-up, it's unnecessarily complex (it's taken from the webpack chrome extension boilerplate)
- 🐞Setting the badge does not work when loading a new page, only when moving to an already-existing tab. There's also unnecessary message passing when the content script responds, could just return the response.
