### PR TITLE
Do not run content script in all frames.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
   "content_scripts": [
     {
       "matches": ["*://*/*"],
-      "all_frames": true,
+      "all_frames": false,
       "run_at": "document_idle",
       "js": ["contentScript.bundle.js"]
     }


### PR DESCRIPTION
Setting the badge currently only works correctly if each tab only runs one content script and not one for every frame. This of course means that we may miss documentation that's in its own iframe but I'd say that's more of a feature than bug for now.

"The "all_frames" field allows the extension to specify if JavaScript and CSS files should be injected into all frames matching the specified URL requirements or only into the topmost frame in a tab.

If specified true, it will inject into all frames, even if the frame is not the topmost frame in the tab. Each frame is checked independently for URL requirements, it will not inject into child frames if the URL requirements are not met."